### PR TITLE
Small refactoring for fifo names

### DIFF
--- a/Client/telemetry.h
+++ b/Client/telemetry.h
@@ -1,6 +1,10 @@
 #ifndef TELEMETRY_
 #define TELEMETRY_
 
+#include "standard.h"
+#include "fifo_parser.h"
+#include "treap.h"
+
 /**
  * Library connecting an app with the functionalities of the
  * Telemetry Daemon. The Daemon needs to be running in order

--- a/Daemon/callback_storage.c
+++ b/Daemon/callback_storage.c
@@ -2,7 +2,6 @@
 #include <stdlib.h>
 
 #include "callback_storage.h"
-#include "standard.h"
 
 struct CallbackNode {
     char* channel;

--- a/Daemon/callback_storage.h
+++ b/Daemon/callback_storage.h
@@ -1,6 +1,8 @@
 #ifndef CALLBACK_STORAGE_
 #define CALLBACK_STORAGE_
 
+#include "standard.h"
+
 /**
  * This storage allows the daemon to store all the registered callbacks
  * made by users. This storage can be seen as a DS with the following

--- a/Daemon/sniffer.c
+++ b/Daemon/sniffer.c
@@ -8,15 +8,8 @@
 #include <errno.h>
 
 #include "sniffer.h"
-#include "fifo_parser.h"
-#include "callback_storage.h"
-#include "history_storage.h"
-#include "standard.h"
 
 FifoParser daemon_parser;
-
-static const char DAEMON_FIFO_CHANNEL[] = "/tmp/TelemetryRequests";
-static const char PERSONAL_RECEIVE_CHANNEL[] = "/tmp/TelemetryReceiveNr";
 
 void SendHistory(int PID, int entries_found, const char** channels, const char** messages)
 {

--- a/Daemon/sniffer.h
+++ b/Daemon/sniffer.h
@@ -1,6 +1,11 @@
 #ifndef SNIFFER_
 #define SNIFFER_
 
+#include "fifo_parser.h"
+#include "callback_storage.h"
+#include "history_storage.h"
+#include "standard.h"
+
 /**
  * Main runtime of the daemon,
  * it's basically listening to the daemon's personal

--- a/Shared/fifo_parser.c
+++ b/Shared/fifo_parser.c
@@ -132,27 +132,3 @@ int PrintString(FifoParser* parser, const char* s, int length)
     return (wr == 1 ? 0 : wr);
 }
 
-void AppendInt(char* s, int nr)
-{
-    if (nr == 0) {
-        s[0] = '0';
-        s[1] = 0;
-        return;
-    }
-
-    char v[10];
-    int p = 0;
-
-    while (nr) {
-        v[p++] = nr % 10 + '0';
-        nr /= 10;
-    }
-
-    while (p) {
-        p--;
-        *s = v[p];
-        s++;
-    }
-    // not zero ending....
-    *s = 0;
-}

--- a/Shared/standard.c
+++ b/Shared/standard.c
@@ -3,6 +3,25 @@
 
 #include "standard.h"
 
+const char DAEMON_FIFO_CHANNEL[] = "/tmp/TelemetryRequests";
+
+const char PERSONAL_QUERY_CHANNEL[] = "/tmp/TelemetryQueryNr";
+const char PERSONAL_RECEIVE_CHANNEL[] = "/tmp/TelemetryReceiveNr";
+
+static int GenerateRandomInt()
+{
+    static int cnt = 0;
+    return cnt++ % 1000 + 1;
+}
+
+char* GenerateRandomFifoName()
+{
+    static char random_fifo_name[MAX_LENGTH_FIFO_NAME];
+    strcpy(random_fifo_name, PERSONAL_QUERY_CHANNEL);
+    AppendInt(random_fifo_name + strlen(random_fifo_name), GenerateRandomInt());
+    return random_fifo_name;
+}
+
 char* CopyString(const char* string)
 {
     int len = strlen(string);
@@ -26,3 +45,28 @@ int IsPrefixOf(const char* big, const char* small)
     return 1;
 }
 
+
+void AppendInt(char* s, int nr)
+{
+    if (nr == 0) {
+        s[0] = '0';
+        s[1] = 0;
+        return;
+    }
+
+    char v[10];
+    int p = 0;
+
+    while (nr) {
+        v[p++] = nr % 10 + '0';
+        nr /= 10;
+    }
+
+    while (p) {
+        p--;
+        *s = v[p];
+        s++;
+    }
+    // zero ending, very important
+    *s = 0;
+}

--- a/Shared/standard.h
+++ b/Shared/standard.h
@@ -2,13 +2,27 @@
 #define STANDARD_
 
 /**
- * Defines a bunch of "standard" functions.
+ * Defines a bunch of "standard" functions and constants.
  */
+
+#define MAX_LENGTH_FIFO_NAME  256
+
+
+extern const char DAEMON_FIFO_CHANNEL[];
+
+extern const char PERSONAL_QUERY_CHANNEL[];
+extern const char PERSONAL_RECEIVE_CHANNEL[];
+
+
+char* GenerateRandomFifoName();
 
 // Create a new copy of the string.
 char* CopyString(const char* string);
 
 // Checks if small is a prefix of big.
 int IsPrefixOf(const char* big, const char* small);
+
+// Ads string representation of int in string s
+void AppendInt(char* s, int nr);
 
 #endif // STANDARD_


### PR DESCRIPTION
Moved definitions of fifo names in a shared file for both client and daemon, also moved `appendInt()` function out from `fifo_parser.c` to `standard.c`